### PR TITLE
Bugfix/fluxject properties

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -157,9 +157,8 @@ export const FluxjectServiceSymbols = Object.freeze({
  * @template {keyof InferRegistrationsFromContainer<TContainer>} TServiceName
  * @template {InferRegistrationsFromContainer<TContainer>[TServiceName]} [TRegistration=GetRegistrationFromContainer<TContainer, TServiceName>]
  * @typedef {InferLifetimeFromRegistration<TRegistration> extends "Transient"|"Singleton"
- *   ? HostServiceProvider<Omit<InferRegistrationsFromContainer<TContainer>, TServiceName>>
- *     & { createScope: () => Widen<Omit<InferRegistrationsFromContainer<TContainer>, TServiceName>> }
- *   : ScopedServiceProvider<Omit<InferRegistrationsFromContainer<TContainer>, TServiceName>>
+ *   ? Widen<Omit<HostServiceProvider<Omit<InferRegistrationsFromContainer<TContainer>, TServiceName>>, keyof FluxjectHostServiceProviderProps<InferRegistrationsFromContainer<TContainer>>>>
+ *   : Widen<Omit<ScopedServiceProvider<Omit<InferRegistrationsFromContainer<TContainer>, TServiceName>>, keyof FluxjectScopedServiceProviderProps<InferRegistrationsFromContainer<TContainer>>>>
  * } InferServiceProvider
  */
 

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -219,5 +219,43 @@ describe('sync services', () => {
             const provider = container.prepare();
             expect(() => provider.createScope()).toThrow();
         });
+
+        it('should throw when attempting to de-reference [createScope] or [dispose] on services from instantiation (strict: false)', () => {
+            let isUndefined = false;
+            class TestService {
+                /**
+                 * 
+                 * @param {import('../src/types.js').InferServiceProvider<typeof container, "test">} services
+                 */
+                constructor(services) {
+                    //@ts-expect-error
+                    const createScope = services.createScope;
+                    //@ts-expect-error
+                    const dispose = services.dispose;
+                    isUndefined = createScope === undefined && dispose === undefined;
+                }
+            }
+
+            const container = Container.create()
+                .register(m => m.singleton({
+                    test: TestService
+                }));
+
+            container.prepare();
+            expect(isUndefined).toBe(true);
+        });
+
+        it('should throw when attempting to de-reference [createScope] or [dispose] on services from instantiation (strict: true)', () => {
+            class TestService {
+                constructor({ createScope, dispose }) { }
+            }
+
+            const container = Container.create({ strict: true })
+                .register(m => m.singleton({
+                    test: TestService
+                }));
+
+            expect(() => container.prepare()).toThrow();
+        });
     });
 });


### PR DESCRIPTION
Cleaned up FluxjectProperties, added a new export called `fluxject()` which is the same as `Container.create()`